### PR TITLE
Remove package.json "engines" entry

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,9 +5,6 @@
   "publisher": "unknown",
   "version": "0.0.0",
   "license": "MIT",
-  "engines": {
-    "@foxglove/studio": ">=0.1.0"
-  },
   "main": "./dist/extension.js",
   "scripts": {
     "foxglove:prepublish": "fox build --mode production",


### PR DESCRIPTION
We can revisit this in the future when we need it. I think a `"foxglove": {}` entry in package.json will be suit our needs better
