### PR TITLE
Install dependencies during `fox create`

### DIFF
--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -36,8 +36,10 @@ describe("createCommand", () => {
     expect(files).toContain("README.md");
     expect(files).toContain("tsconfig.json");
 
-    const packageJson = await readFile(path.join(destDir, "package.json"), { encoding: "utf8" });
-    expect(packageJson.includes("${NAME}")).not.toBeTruthy();
-    expect(packageJson.includes("extension-test"));
+    const packageJsonStr = await readFile(path.join(destDir, "package.json"), { encoding: "utf8" });
+    expect(packageJsonStr.includes("${NAME}")).not.toBeTruthy();
+    expect(packageJsonStr.includes("extension-test"));
+    const packageJson = JSON.parse(packageJsonStr) as Record<string, unknown>;
+    expect(typeof (packageJson.devDependencies as Record<string, string>).react).toEqual("string");
   });
 });

--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -6,6 +6,8 @@ import { createCommand } from "./create";
 
 let tmpdir: string;
 
+jest.setTimeout(30 * 1000);
+
 jest.mock("./log.ts", () => ({
   info: jest.fn(),
   fatal: jest.fn((msg) => {
@@ -28,7 +30,8 @@ describe("createCommand", () => {
     const dirs = contents.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
     const files = contents.filter((entry) => entry.isFile()).map((entry) => entry.name);
 
-    expect(dirs).toHaveLength(1);
+    expect(dirs).toHaveLength(2);
+    expect(dirs).toContain("node_modules");
     expect(dirs).toContain("src");
 
     expect(files).toContain("CHANGELOG.md");

--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -6,7 +6,7 @@ import { createCommand } from "./create";
 
 let tmpdir: string;
 
-jest.setTimeout(30 * 1000);
+jest.setTimeout(60 * 1000);
 
 jest.mock("./log.ts", () => ({
   info: jest.fn(),

--- a/template/package.json
+++ b/template/package.json
@@ -14,24 +14,5 @@
     "local-install": "fox install",
     "package": "fox package",
     "pretest": "fox pretest"
-  },
-  "devDependencies": {
-    "@foxglove/eslint-plugin": "^0",
-    "@foxglove/fox": "^1",
-    "@foxglove/studio": "^0",
-    "@types/react": "^17",
-    "@types/react-dom": "^17",
-    "@typescript-eslint/eslint-plugin": "^4",
-    "@typescript-eslint/parser": "^4",
-    "eslint-config-prettier": "^8",
-    "eslint-plugin-import": "^2",
-    "eslint-plugin-prettier": "^3",
-    "eslint-plugin-react-hooks": "^4",
-    "eslint-plugin-react": "^7",
-    "eslint": "^7",
-    "prettier": "^2",
-    "react": "^17",
-    "react-dom": "^17",
-    "typescript": "^4"
   }
 }


### PR DESCRIPTION
This has the benefit of fetching latest version numbers for our dependencies from npm and encoding them in package.json, and creating the node_modules folder for new extensions
