### PR TITLE
Fix setRenderDone call in ExamplePanel.tsx

### DIFF
--- a/template/src/ExamplePanel.tsx
+++ b/template/src/ExamplePanel.tsx
@@ -23,7 +23,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
       // rendering before the next render call, studio shows a notification to the user that your panel is delayed.
       //
       // Set the done callback into a state variable to trigger a re-render.
-      setRenderDone(done);
+      setRenderDone(() => done);
 
       // We may have new topics - since we are also watching for messages in the current frame, topics may not have changed
       // It is up to you to determine the correct action when state has not changed.


### PR DESCRIPTION
React state setters actually _call_ a function argument rather than set the state to the function so we need to wrap the function with another function.