### PR TITLE
Cheap fix for #40

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -24,7 +24,7 @@ const DEPENDENCIES = [
   "prettier",
   "react",
   "react-dom",
-  "typescript",
+  "typescript@4.6.x",
 ];
 
 export interface CreateOptions {


### PR DESCRIPTION
Not a good solution, but proving that holding typescript@4.6.x fixes #40 