### PR TITLE
Pin typescript dependency to 4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/fox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "foxglove",
   "description": "Foxglove Studio Extension Manager",
   "license": "MIT",

--- a/src/create.ts
+++ b/src/create.ts
@@ -24,7 +24,7 @@ const DEPENDENCIES = [
   "prettier",
   "react",
   "react-dom",
-  "typescript",
+  "typescript@4.6",
 ];
 
 export interface CreateOptions {


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
This pins the version of typescript we specify in generated extensions to 4.6 until the issues with 4.7 can be resolved.

<!-- link relevant GitHub issues -->
Fixes #40 