### PR TITLE
Improve template panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/fox",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "foxglove",
   "description": "Foxglove Studio Extension Manager",
   "license": "MIT",

--- a/template/src/ExamplePanel.tsx
+++ b/template/src/ExamplePanel.tsx
@@ -54,10 +54,25 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   }, [renderDone]);
 
   return (
-    <>
-      <div>{topics?.join(",")}</div>
+    <div style={{ padding: "1rem" }}>
+      <h2>Welcome to your new extension panel!</h2>
+      <p>
+        Check the{" "}
+        <a href="https://foxglove.dev/docs/studio/extensions/getting-started">documentation</a> for
+        more details on building extension panels for Foxglove Studio.
+      </p>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", rowGap: "0.2rem" }}>
+        <b style={{ borderBottom: "1px solid" }}>Topic</b>
+        <b style={{ borderBottom: "1px solid" }}>Datatype</b>
+        {(topics ?? []).map((topic) => (
+          <>
+            <div key={topic.name}>{topic.name}</div>
+            <div key={topic.datatype}>{topic.datatype}</div>
+          </>
+        ))}
+      </div>
       <div>{messages?.length}</div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
**Public-Facing Changes**
This improves the example panel content and layout.


**Description**
The existing panel just displays a series of `[object]*` text and is confusing to users and looks like it might be an error. This improves the example panel to display a welcome message and a table of available topics.

<img width="911" alt="Screen Shot 2022-06-02 at 1 55 33 PM" src="https://user-images.githubusercontent.com/93935560/171738220-e4d8b790-c287-463f-bbeb-5c5f918dcc91.png">

<!-- link relevant GitHub issues -->
