### PR TITLE
Use magic publicPath prefix for loading extension resources

### DIFF
--- a/src/webpackConfigExtension.ts
+++ b/src/webpackConfigExtension.ts
@@ -18,6 +18,7 @@ export default (
     entry: entryPoint,
     output: {
       path: path.join(resolvedExtensionPath, "dist"),
+      publicPath: "@FOXGLOVE_EXTENSION_PATH_PREFIX@/dist/",
       filename: "extension.js",
       libraryTarget: "commonjs2",
     },


### PR DESCRIPTION
**Public-Facing Changes**
This updates the default value of the `output.publicPath` setting in the Webpack config to use a magic value that is substituted at extension load time by Studio.

Existing extensions will need to update the version of their `@foxglove/fox` dependency to adopt the new default. It is unlikely any existing extensions would have a conflict with the new `publicPath` value.

**Description**
Necessary for allowing extensions to load resources from their bundles as implemented in https://github.com/foxglove/studio/pull/3413.

Webpack uses the `publicPath` as the base path for resolving relative paths.

Using the magic value lets Studio itself determine what the appropriate base path is, which would vary between the desktop app and the web app, and can remain an internal implementation detail should there be a change in the future.