### PR TITLE
Add "dom" to tsconfig.json lib attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/fox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "foxglove",
   "description": "Foxglove Studio Extension Manager",
   "license": "MIT",

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "lib": ["dom"],
 
     // Additional TypeScript error reporting checks are enabled by default to improve code quality.
     // Enable/disable these checks as necessary to suit your coding preferences or work with

--- a/tsconfig/tsconfig.json
+++ b/tsconfig/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",
-    "lib": ["es2020"],
+    "lib": ["es2020", "dom"],
     "moduleResolution": "node",
     "jsx": "react-jsx",
     "newLine": "lf",

--- a/tsconfig/tsconfig.json
+++ b/tsconfig/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020"],
     "moduleResolution": "node",
     "jsx": "react-jsx",
     "newLine": "lf",


### PR DESCRIPTION
**Public-Facing Changes**

Adds the `dom` library to tsconfig.json so DOM-specific APIs can be used in extension panels.

**Description**

Fixes https://github.com/foxglove/fox/issues/48